### PR TITLE
Improve Laravel Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This package can be installed through Composer.
 composer require urlbox/screenshots
 ```
 
-When using Laravel there is a service provider that you can make use of:
+When using Laravel, if you are using a version older than v5.5 you will need to include the Service Provider manually:
 
 ```php
 // app/config/app.php

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This package can be installed through Composer.
 composer require urlbox/screenshots
 ```
 
-When using Laravel, if you are using a version older than v5.5 you will need to include the Service Provider manually:
+When using Laravel, if you are using a version pre v5.5 you will need to include the Service Provider manually:
 
 ```php
 // app/config/app.php

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "urlbox/screenshots",
-  "version": "2.0.5",
+  "version": "2.1.0",
   "description": "Use urlbox to easily generate website thumbnail screenshots from a URL",
   "homepage": "https://github.com/urlbox-io/urlbox-screenshots-php",
   "keywords": [

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "urlbox/screenshots",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Use urlbox to easily generate website thumbnail screenshots from a URL",
   "homepage": "https://github.com/urlbox-io/urlbox-screenshots-php",
   "keywords": [
@@ -45,6 +45,16 @@
   "autoload-dev": {
     "psr-4": {
       "Urlbox\\Screenshots\\Tests\\": "tests/"
+    }
+  },
+  "extra": {
+    "laravel": {
+        "providers": [
+            "Urlbox\\Screenshots\\UrlboxProvider"
+        ],
+        "aliases": {
+            "Urlbox": "Urlbox\\Screenshots\\Facade\\Urlbox"
+        }
     }
   }
 }

--- a/src/UrlboxProvider.php
+++ b/src/UrlboxProvider.php
@@ -3,14 +3,23 @@
 namespace Urlbox\Screenshots;
 
 use Illuminate\Support\ServiceProvider;
+use InvalidArgumentException;
 
 class UrlboxProvider extends ServiceProvider
 {
     public function register()
     {
-        $this->app->singleton('urlbox',function() {
-            $config = config('services.urlbox');
-            return new Urlbox($config['key'], $config['secret']);
+        $this->app->singleton( Urlbox::class, function() {
+            $key    = config( 'services.urlbox.key' );
+            $secret = config( 'services.urlbox.secret' );
+
+            if ( ! $key || ! $secret ) {
+                throw new InvalidArgumentException( 'Please ensure you have set values for `services.urlbox.key` and `services.urlbox.secret`' );
+            }
+
+            return new Urlbox( $key, $secret );
         });
+
+        $this->app->alias( Urlbox::class, 'urlbox' );
     }
 }


### PR DESCRIPTION
This PR includes the follow:

1. Laravel Package Auto Discovery - for people using Laravel 5.5 or newer, they no longer need to register the service provider in their applicate, it will be auto discovered. This is a non-breaking change as there is no problem if a package is auto discovered and manually registered.
2. Changed Container Binging - I have changed the container binding to use `Urlbox::class` as the default binding, and `'urlbox'` as an alias of this. The alias means that this is also not a breaking change.
3. Added exception with helpful message when Key/Secret not supplied (Laravel) - If you tried accessing the container binding in laravel without adding the config values, you would get an error about using `null` as an array. I have reworked how the config values are retrieved, and added a check to ensure both key and secret and supplied, otherwise an `InvalidArgumentException` is thrown. It's possible that this is a breaking change, but it's not easy for me to check. Older version of PHP allowed for crazy things like trying to use a `null` like an array, but newer versions are more strict and throw an expect (like what I experienced).

If we think this counts as a breaking change (or if we just want to be safe), we'll want to update the version to `3.0.0`